### PR TITLE
Fix docker-compose config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,8 @@ POSTGRES_PASSWORD=changeme
 
 # Redis
 REDIS_ARGS="--requirepass changeme"
+
+# PgAdmin
+PGADMIN_LISTEN_PORT=5050
+PGADMIN_DEFAULT_EMAIL=admin@madtoshi.com
+PGADMIN_DEFAULT_PASSWORD=changeme

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,18 @@
+# Backend
 NODE_ENV=development
-DB_NAME=name
-DB_USER=user
-DB_PASS=pass
+DB_NAME=envelope_db
+DB_USER=pguser
+DB_PASS=changeme
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_USER=default
+REDIS_PASSWORD=changeme
+SESSION_SECRET=changeme
+
+# Postgres
+POSTGRES_DB=envelope_db
+POSTGRES_USER=pguser
+POSTGRES_PASSWORD=changeme
+
+# Redis
+REDIS_ARGS="--requirepass changeme"

--- a/api/config/redis-config.js
+++ b/api/config/redis-config.js
@@ -2,7 +2,11 @@ const redis = require('redis');
 
 let redisClient;
 (async () => {
-    redisClient = redis.createClient({ host:'redis', port: 6379 });
+    redisClient = redis.createClient({
+        url: `redis://${process.env.REDIS_HOST}:${process.env.REDIS_PORT}`,
+        username: process.env.REDIS_USER,
+        password: process.env.REDIS_PASSWORD,
+     });
 
     redisClient.on("error", (error) => console.error(`Error Redis: ${error}`));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,24 +4,23 @@ services:
     build: .
     ports:
       - 8080:8080
-    environment:
-      DB_HOST: db
-      REDIS_HOST: redis
+    env_file:
+      - .env
     depends_on:
       - db
       - redis
 
   db: 
     image: postgres
-    environment: 
-      POSTGRES_USER: 
-      POSTGRES_PASSWORD: 
-      POSTGRES_DB: 
+    env_file:
+      - .env
     volumes:
-     - db-data:/db-data
+      - db-data:/db-data
   
   redis: 
     image: redis
+    env_file:
+      - .env
     volumes: 
       - cache-data:/cache-data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,16 @@ services:
     env_file:
       - .env
     volumes:
-      - db-data:/db-data
+      - db-data:/db-
+      
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - 5050:5050
+    depends_on:
+      - db
+    env_file:
+      - .env
   
   redis: 
     image: redis


### PR DESCRIPTION
Sets up the docker stack so the backend can connect to redis/postgres.

You just need to copy the new .env.sample to .env in the same folder and change the passwords if you want.

Then:
```
# if the stack is still running
$ docker compose -f docker-compose.yml down
# rebuild
$ docker compose -f docker-compose.yml build
# restart
$ docker compose -f docker-compose.yml up 
```

Not sure if the node app seeds its own db with any users to start, may need to add a script for that. LMK and can help with that next.

----

I also added pgadmin, which can be nice rather than having to use the psql CLI directly - feel free to take that or leave it.

Once your stack's up:
- open a browser to localhost:5050
- the db host will be the docker network's internal hostname for your `db` service, just like your backend connects to it: "db"
